### PR TITLE
Feature/#5 jayun

### DIFF
--- a/src/apis/todoApi.js
+++ b/src/apis/todoApi.js
@@ -40,3 +40,20 @@ export const getTodos = async () => {
     console.error(error);
   }
 };
+
+export const updateTodo = async (id, updatedTodo) => {
+  try {
+    const response = await todoInstance.put(`/${id}`, updatedTodo);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const deleteTodo = async (id) => {
+  try {
+    await todoInstance.delete(`/${id}`);
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/components/TodoItem/hook.jsx
+++ b/src/components/TodoItem/hook.jsx
@@ -1,0 +1,34 @@
+import { updateTodo } from 'apis/todoApi';
+import { useInput } from 'hooks/useInput';
+import { useEffect, useState } from 'react';
+
+export const useTodoItem = (id, setIsUpdated, isUpdated, todo, isCompleted) => {
+  const { value: todoValue, onChange: onTodoChange } = useInput(todo);
+  const [isEdit, setIsEdit] = useState(false);
+  const [updatedTodoId, setUpdatedTodoId] = useState(null);
+
+  const changeEditState = () => {
+    setIsEdit((prev) => !prev);
+  };
+
+  const handleUpdateTodo = async () => {
+    await updateTodo(id, { todo: todoValue, isCompleted });
+    setIsUpdated(true);
+    setUpdatedTodoId(id);
+  };
+
+  useEffect(() => {
+    if (!isUpdated && updatedTodoId === id) {
+      setIsEdit(false);
+      setUpdatedTodoId(null);
+    }
+  }, [isUpdated]);
+
+  return {
+    isEdit,
+    onTodoChange,
+    todoValue,
+    handleUpdateTodo,
+    changeEditState,
+  };
+};

--- a/src/components/TodoItem/index.jsx
+++ b/src/components/TodoItem/index.jsx
@@ -1,8 +1,6 @@
-import { updateTodo } from 'apis/todoApi';
-import { useInput } from 'hooks/useInput';
-import { useEffect, useState } from 'react';
+import { useTodoItem } from './hook';
 
-export const TodoListItem = ({
+export const TodoItem = ({
   id,
   todo,
   isCompleted,
@@ -11,26 +9,13 @@ export const TodoListItem = ({
   setIsUpdated,
   isUpdated,
 }) => {
-  const { value: todoValue, onChange: onTodoChange } = useInput(todo);
-  const [isEdit, setIsEdit] = useState(false);
-  const [updatedTodoId, setUpdatedTodoId] = useState(null);
-
-  const changeEditState = () => {
-    setIsEdit((prev) => !prev);
-  };
-
-  const handleUpdateTodo = async () => {
-    await updateTodo(id, { todo: todoValue, isCompleted });
-    setIsUpdated(true);
-    setUpdatedTodoId(id);
-  };
-
-  useEffect(() => {
-    if (!isUpdated && updatedTodoId === id) {
-      setIsEdit(false);
-      setUpdatedTodoId(null);
-    }
-  }, [isUpdated]);
+  const { isEdit, onTodoChange, todoValue, handleUpdateTodo, changeEditState } = useTodoItem(
+    id,
+    setIsUpdated,
+    isUpdated,
+    todo,
+    isCompleted,
+  );
 
   return (
     <li>

--- a/src/components/TodoListItem.jsx
+++ b/src/components/TodoListItem.jsx
@@ -1,13 +1,36 @@
+import { updateTodo } from 'apis/todoApi';
 import { useInput } from 'hooks/useInput';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-export const TodoListItem = ({ todo, isCompleted, onCheckBoxChange, onDelete }) => {
-  const [isEdit, setIsEdit] = useState(false);
+export const TodoListItem = ({
+  id,
+  todo,
+  isCompleted,
+  onCheckBoxChange,
+  onDelete,
+  setIsUpdated,
+  isUpdated,
+}) => {
   const { value: todoValue, onChange: onTodoChange } = useInput(todo);
+  const [isEdit, setIsEdit] = useState(false);
+  const [updatedTodoId, setUpdatedTodoId] = useState(null);
 
   const changeEditState = () => {
     setIsEdit((prev) => !prev);
   };
+
+  const handleUpdateTodo = async () => {
+    await updateTodo(id, { todo: todoValue, isCompleted });
+    setIsUpdated(true);
+    setUpdatedTodoId(id);
+  };
+
+  useEffect(() => {
+    if (!isUpdated && updatedTodoId === id) {
+      setIsEdit(false);
+      setUpdatedTodoId(null);
+    }
+  }, [isUpdated]);
 
   return (
     <li>
@@ -16,7 +39,9 @@ export const TodoListItem = ({ todo, isCompleted, onCheckBoxChange, onDelete }) 
         {isEdit ? (
           <>
             <input data-testid='modify-input' onChange={onTodoChange} value={todoValue} />
-            <button data-testid='submit-button'>제출</button>
+            <button data-testid='submit-button' onClick={handleUpdateTodo}>
+              제출
+            </button>
             <button data-testid='cancel-button' onClick={changeEditState}>
               취소
             </button>

--- a/src/pages/Todo/hook.jsx
+++ b/src/pages/Todo/hook.jsx
@@ -1,0 +1,50 @@
+import { useLoaderData } from 'react-router-dom';
+import { useInput } from 'hooks/useInput';
+import { createTodo, getTodos, updateTodo, deleteTodo } from 'apis/todoApi';
+import { useEffect, useState } from 'react';
+
+export const useTodo = () => {
+  const { data: loadedTodoData } = useLoaderData();
+  const [todos, setTodos] = useState(loadedTodoData);
+  const [isUpdated, setIsUpdated] = useState(false);
+  const { value: todoValue, onReset: resetTodo, onChange: onTodoChange } = useInput();
+
+  const refetchTodos = async () => {
+    const refetchedTodos = await getTodos();
+    setTodos(refetchedTodos);
+    setIsUpdated(false);
+  };
+
+  useEffect(() => {
+    refetchTodos();
+  }, [isUpdated]);
+
+  const handleCreateTodo = async (e) => {
+    e.preventDefault();
+    if (!todoValue) return;
+    await createTodo({ todo: todoValue });
+    setIsUpdated(true);
+    resetTodo();
+  };
+
+  const handleCheckBoxChange = async (id, todo, isCompleted) => {
+    await updateTodo(id, { todo, isCompleted: !isCompleted });
+    setIsUpdated(true);
+  };
+
+  const handleDeleteClick = async (id) => {
+    await deleteTodo(id);
+    setIsUpdated(true);
+  };
+
+  return {
+    todos,
+    todoValue,
+    isUpdated,
+    setIsUpdated,
+    onTodoChange,
+    handleCreateTodo,
+    handleCheckBoxChange,
+    handleDeleteClick,
+  };
+};

--- a/src/pages/Todo/index.jsx
+++ b/src/pages/Todo/index.jsx
@@ -1,6 +1,6 @@
 import { useLoaderData } from 'react-router-dom';
 import { useInput } from 'hooks/useInput';
-import { createTodo, getTodos, updateTodo } from 'apis/todoApi';
+import { createTodo, getTodos, updateTodo, deleteTodo } from 'apis/todoApi';
 import { useEffect, useState } from 'react';
 import { TodoListItem } from 'components/TodoListItem';
 
@@ -33,6 +33,11 @@ export const Todo = () => {
     setIsUpdated(true);
   };
 
+  const handleDeleteClick = async (id) => {
+    await deleteTodo(id);
+    setIsUpdated(true);
+  };
+
   return (
     <>
       <h1>✅ Todo List</h1>
@@ -55,6 +60,7 @@ export const Todo = () => {
               isUpdated={isUpdated}
               setIsUpdated={setIsUpdated}
               onCheckBoxChange={() => handleCheckBoxChange(id, todo, isCompleted)}
+              onDelete={() => handleDeleteClick(id)}
             />
           );
         })}

--- a/src/pages/Todo/index.jsx
+++ b/src/pages/Todo/index.jsx
@@ -1,4 +1,4 @@
-import { TodoListItem } from 'components/TodoListItem';
+import { TodoItem } from 'components/TodoItem';
 import { useTodo } from 'pages/Todo/hook';
 export const Todo = () => {
   const {
@@ -26,7 +26,7 @@ export const Todo = () => {
       <ul>
         {todos.map(({ id, todo, isCompleted }) => {
           return (
-            <TodoListItem
+            <TodoItem
               key={id}
               id={id}
               todo={todo}

--- a/src/pages/Todo/index.jsx
+++ b/src/pages/Todo/index.jsx
@@ -41,7 +41,16 @@ export const Todo = () => {
       <h3>📄 나의 할 일 목록</h3>
       <ul>
         {todos.map(({ id, todo, isCompleted }) => {
-          return <TodoListItem key={id} id={id} todo={todo} isCompleted={isCompleted} />;
+          return (
+            <TodoListItem
+              key={id}
+              id={id}
+              todo={todo}
+              isCompleted={isCompleted}
+              isUpdated={isUpdated}
+              setIsUpdated={setIsUpdated}
+            />
+          );
         })}
       </ul>
     </>

--- a/src/pages/Todo/index.jsx
+++ b/src/pages/Todo/index.jsx
@@ -1,6 +1,6 @@
 import { useLoaderData } from 'react-router-dom';
 import { useInput } from 'hooks/useInput';
-import { createTodo, getTodos } from 'apis/todoApi';
+import { createTodo, getTodos, updateTodo } from 'apis/todoApi';
 import { useEffect, useState } from 'react';
 import { TodoListItem } from 'components/TodoListItem';
 
@@ -28,6 +28,11 @@ export const Todo = () => {
     resetTodo();
   };
 
+  const handleCheckBoxChange = async (id, todo, isCompleted) => {
+    await updateTodo(id, { todo, isCompleted: !isCompleted });
+    setIsUpdated(true);
+  };
+
   return (
     <>
       <h1>✅ Todo List</h1>
@@ -49,6 +54,7 @@ export const Todo = () => {
               isCompleted={isCompleted}
               isUpdated={isUpdated}
               setIsUpdated={setIsUpdated}
+              onCheckBoxChange={() => handleCheckBoxChange(id, todo, isCompleted)}
             />
           );
         })}

--- a/src/pages/Todo/index.jsx
+++ b/src/pages/Todo/index.jsx
@@ -1,42 +1,16 @@
-import { useLoaderData } from 'react-router-dom';
-import { useInput } from 'hooks/useInput';
-import { createTodo, getTodos, updateTodo, deleteTodo } from 'apis/todoApi';
-import { useEffect, useState } from 'react';
 import { TodoListItem } from 'components/TodoListItem';
-
+import { useTodo } from 'pages/Todo/hook';
 export const Todo = () => {
-  const { data: loadedTodoData } = useLoaderData();
-  const [todos, setTodos] = useState(loadedTodoData);
-  const [isUpdated, setIsUpdated] = useState(false);
-  const { value: todoValue, onReset: resetTodo, onChange: onTodoChange } = useInput();
-
-  const refetchTodos = async () => {
-    const refetchedTodos = await getTodos();
-    setTodos(refetchedTodos);
-    setIsUpdated(false);
-  };
-
-  useEffect(() => {
-    refetchTodos();
-  }, [isUpdated]);
-
-  const handleCreateTodo = async (e) => {
-    e.preventDefault();
-    if (!todoValue) return;
-    await createTodo({ todo: todoValue });
-    setIsUpdated(true);
-    resetTodo();
-  };
-
-  const handleCheckBoxChange = async (id, todo, isCompleted) => {
-    await updateTodo(id, { todo, isCompleted: !isCompleted });
-    setIsUpdated(true);
-  };
-
-  const handleDeleteClick = async (id) => {
-    await deleteTodo(id);
-    setIsUpdated(true);
-  };
+  const {
+    todos,
+    todoValue,
+    isUpdated,
+    setIsUpdated,
+    onTodoChange,
+    handleCreateTodo,
+    handleCheckBoxChange,
+    handleDeleteClick,
+  } = useTodo();
 
   return (
     <>


### PR DESCRIPTION
# Third Pull Request

벌써 세 번째 PR이네요! 끝이 얼마 남지 않았습니다. 끝까지 화이팅입니다 🔥

## 로직 설명

### 1. Todo update 기능 구현

```jsx
// components/TodoItem/hook.jsx

const handleUpdateTodo = async () => {
  await updateTodo(id, { todo: todoValue, isCompleted });
  setIsUpdated(true);
  setUpdatedTodoId(id);
};

useEffect(() => {
  if (!isUpdated && updatedTodoId === id) {
    setIsEdit(false);
    setUpdatedTodoId(null);
  }
}, [isUpdated]);
```

- Todo update의 로직은 다음과 같습니다.

1. 사용자가 Todo를 수정하고, 제출 버튼을 클릭하면 `handleUpdateTodo` 함수가 호출됩니다.
2. isUpdated 플래그 변수가 true로 변경되어 refetch 함수가 실행됩니다.
3. 서버에서 새로운 todo를 받아 렌더링하고, isUpdated 플래그 변수를 false로 변경합니다.
4. isUpdated 변수가 변경되어 useEffect에 등록한 함수가 실행되고, isEdit 상태 변수를 false로 변경하여 input을 숨겨줍니다.

- useEffect를 쓴 이유는 다음과 같습니다.
  - 만약 useEffect를 쓰지 않고 handleUpdateTodo 함수에서 바로 `setIsEdit(false)`를 호출한다면, 아직 서버에서 데이터를 받아 렌더링을 하기도 전에 input이 숨겨집니다. 즉 수정 전의 todo가 한 번 보인 후, 렌더링이 되는 것입니다. 이것은 사용자에게 어색한 경험을 줄 수 있습니다.

### 2. 비즈니스 로직 `useTodo`, `useTodoItem` hook으로 분리

- Todo, TodoItem 컴포넌트에서 비즈니스 로직을 분리하기 위해 hook으로 분리했습니다.
- 이 hook을 기존에 있던 hooks 폴더에 위치시킬수도 있었지만, 관련 있는 코드들은 가깝게 있도록 응집도를 높이기 위해 해당 컴포넌트의 폴더에 있는 게 좋다고 생각했습니다.
- hooks 폴더에는 좀 더 공통적으로 사용할 수 있는 hook들을 모아놓고, 다른 컴포넌트에서 재사용하기 위한 용도가 아닌 비즈니스 로직을 분리하기 위한 용도의 hook은 해당 컴포넌트의 폴더에 위치시켰습니다.

```
📦src
 ┣ 📂apis
 ┣ 📂components
 ┃ ┗ 📂TodoItem
 ┃ ┃ ┣ 📜hook.jsx # 비즈니스 로직을 분리하기 위한 용도의 Hook
 ┃ ┃ ┗ 📜index.jsx
 ┣ 📂constants
 ┣ 📂hooks # 다른 컴포넌트에서 공통적으로 사용될 수 있는 Hooks
 ┃ ┣ 📜useCheckAccount.jsx
 ┃ ┣ 📜useInput.jsx
 ┃ ┗ 📜useMovePage.jsx
 ┣ 📂pages
 ┃ ┣ 📂Error
 ┃ ┣ 📂Root
 ┃ ┣ 📂SignIn
 ┃ ┣ 📂SignUp
 ┃ ┣ 📂Todo
 ┃ ┃ ┣ 📜hook.jsx # 비즈니스 로직을 분리하기 위한 용도의 Hook
 ┃ ┃ ┣ 📜index.jsx
 ┃ ┃ ┗ 📜loader.js
 ┃ ┗ 📜index.js
 ┗ 📂utils
```
